### PR TITLE
Filesystem-less usability enhancements

### DIFF
--- a/scamp/config.go
+++ b/scamp/config.go
@@ -114,18 +114,18 @@ func (conf *Config) ServiceCertPath(serviceName string) (certPath []byte) {
 }
 
 // DiscoveryMulticastIP returns the configured discovery address, or the default one
-// if there is no configured address.
+// if there is no configured address (discovery.multicast_address)
 func (conf *Config) DiscoveryMulticastIP() (ip net.IP) {
 	rawAddr := conf.values["discovery.multicast_address"]
 	if rawAddr != nil {
-		return net.IP(rawAddr)
+		return net.ParseIP(string(rawAddr))
 	}
 
 	return defaultGroupIP
 }
 
 // DiscoveryMulticastPort returns the configured discovery port, or the default one
-// if there is no configured port.
+// if there is no configured port (discovery.port)
 func (conf *Config) DiscoveryMulticastPort() (port int) {
 	portBytes := conf.values["discovery.port"]
 	if portBytes != nil {

--- a/scamp/config.go
+++ b/scamp/config.go
@@ -1,12 +1,12 @@
 package scamp
 
 import (
-  "os"
-  "bufio"
-  "regexp"
-  "fmt"
-  "strconv"
-  "net"
+	"bufio"
+	"fmt"
+	"net"
+	"os"
+	"regexp"
+	"strconv"
 )
 
 type Config struct {
@@ -18,7 +18,10 @@ type Config struct {
 var defaultConfig *Config
 
 var defaultAnnounceInterval = 5
+
+// DefaultConfigPath is the path at which the library will, by default, look for its configuration.
 var DefaultConfigPath = "/etc/SCAMP/soa.conf"
+
 var configLine = regexp.MustCompile(`^\s*([\S^=]+)\s*=\s*([\S]+)`)
 var globalConfig *Config
 
@@ -27,7 +30,7 @@ var defaultGroupPort = 5555
 
 func initConfig(configPath string) (err error) {
 	defaultConfig = NewConfig()
-	err = defaultConfig.Load(configPath)
+	err = DefaultConfig().Load(configPath)
 	if err != nil {
 		err = fmt.Errorf("could not load config: %s", err)
 		return
@@ -38,6 +41,7 @@ func initConfig(configPath string) (err error) {
 	return
 }
 
+// NewConfig creates a new configuration struct with default values initialized.
 func NewConfig() (conf *Config) {
 	conf = new(Config)
 	conf.values = make(map[string][]byte)
@@ -45,14 +49,26 @@ func NewConfig() (conf *Config) {
 	return
 }
 
+// SetDefaultConfig sets the global configuration manually if need be.
+// In general, users should use Initialize instead.
+func SetDefaultConfig(conf *Config) {
+	defaultConfig = conf
+}
+
+// DefaultConfig fetches the global configuration struct for use.
+// This function panics if the global configuration is not initialized (with `Initialize()`).
 func DefaultConfig() (conf *Config) {
+	if defaultConfig == nil {
+		panic("Global configuration defaultConfig is not initialized! Call scamp.Initialize() before using package functionality.")
+	}
 	return defaultConfig
 }
 
+// Load loads configuration k/v pairs from the file at the given path.
 func (conf *Config) Load(configPath string) (err error) {
-	file,err := os.Open(configPath)
+	file, err := os.Open(configPath)
 	if err != nil {
-		err = fmt.Errorf("no such file `%s`", configPath)
+		err = fmt.Errorf("couldn't read config from `%s`: %v", configPath, err)
 		return
 	}
 	scanner := bufio.NewScanner(file)
@@ -78,22 +94,26 @@ func (conf *Config) doLoad(scanner *bufio.Scanner) (err error) {
 	return
 }
 
+// ServiceKeyPath uses the configuration to generate a path at which the key for the given service name should be found.
 func (conf *Config) ServiceKeyPath(serviceName string) (keyPath []byte) {
 	path := conf.values[serviceName+".soa_key"]
 	if path == nil {
-		path = []byte("/etc/GT_private/services/" + serviceName + ".key")
+		path = []byte(fmt.Sprintf("/etc/GT_private/services/%s.key", serviceName))
 	}
 	return path
 }
 
+// ServiceCertPath uses the configuration to generate a path at which the certificate for the given service name should be found.
 func (conf *Config) ServiceCertPath(serviceName string) (certPath []byte) {
 	path := conf.values[serviceName+".soa_cert"]
 	if path == nil {
-		path = []byte("/etc/GT_private/services/" + serviceName + ".crt")
+		path = []byte(fmt.Sprintf("/etc/GT_private/services/%s.crt", serviceName))
 	}
 	return path
 }
 
+// DiscoveryMulticastIP returns the configured discovery address, or the default one
+// if there is no configured address.
 func (conf *Config) DiscoveryMulticastIP() (ip net.IP) {
 	rawAddr := conf.values["discovery.multicast_address"]
 	if rawAddr != nil {
@@ -103,10 +123,12 @@ func (conf *Config) DiscoveryMulticastIP() (ip net.IP) {
 	return defaultGroupIP
 }
 
+// DiscoveryMulticastPort returns the configured discovery port, or the default one
+// if there is no configured port.
 func (conf *Config) DiscoveryMulticastPort() (port int) {
-	port_bytes := conf.values["discovery.port"]
-	if port_bytes != nil {
-		port64, err := strconv.ParseInt(string(port_bytes), 10, 0)
+	portBytes := conf.values["discovery.port"]
+	if portBytes != nil {
+		port64, err := strconv.ParseInt(string(portBytes), 10, 0)
 		if err != nil {
 			Error.Printf("could not parse discovery.port `%s`. falling back to default", err)
 			port = int(defaultGroupPort)
@@ -121,8 +143,15 @@ func (conf *Config) DiscoveryMulticastPort() (port int) {
 	return
 }
 
+// Get returns the value of a given config option as a string, or false if it is not set.
 func (conf *Config) Get(key string) (value string, ok bool) {
-	valueBytes,ok := conf.values[key]
+	valueBytes, ok := conf.values[key]
 	value = string(valueBytes)
 	return
+}
+
+// Set sets the given key to the given value in the configuration
+func (conf *Config) Set(key string, value string) {
+	valueBytes := []byte(value)
+	conf.values[key] = valueBytes
 }

--- a/scamp/config.go
+++ b/scamp/config.go
@@ -52,6 +52,7 @@ func NewConfig() (conf *Config) {
 // SetDefaultConfig sets the global configuration manually if need be.
 // In general, users should use Initialize instead.
 func SetDefaultConfig(conf *Config) {
+	initSCAMPLogger()
 	defaultConfig = conf
 }
 

--- a/scamp/scamp.go
+++ b/scamp/scamp.go
@@ -5,48 +5,10 @@ SCAMP provides SOA bus RPC functionality. Please see root SCAMP/README.md for de
 
 Basics
 
-Services and requesters communicate over persistent TLS connections. First, initialize your environment according to the root README.md. You must have a valid certificate and key to present a service.
+Services and requesters communicate over persistent TLS connections.
+First, initialize your environment according to the root README.md. You must have a valid certificate and key to present a service.
 
-Listening For Requests
-
-  service,err := scamp.NewService(30100)
-  if err != nil {
-	fmt.Printf("could not create service")
-	return
-  }
-  service.Register("helloworld.hello", func(sess *scamp.Session){
-  })
-  service.AcceptSessions()
-
-Making a Request against a Service
-
-  conn,err := scamp.Connect(":30100")
-  if err != nil {
-	fmt.Printf("could not connect to service")
-	return
-  }
-  sess,err := conn.Send(scamp.Request{
-    Action:         "helloworld.hello",
-    EnvelopeFormat: scamp.ENVELOPE_JSON,
-    Version:        1,
-  })
-  if err != nil {
-	fmt.Printf("could not send reqest")
-	return
-  }
-  var reply Reply = sess.Recv()
-
-Library Internals
-
-SCAMP is a layered architecture:
-
-  Request/Reply
-  -------------
-  Session
-  -------------
-  Connection
-  -------------
-  Service
+Every program must call `scamp.Initialize()` before doing anything else, to initialize the global configuration.
 
 */
 package scamp
@@ -57,7 +19,7 @@ import (
 
 var defaultCache *ServiceCache
 
-//Initialize Package-level setup. Right now it just sets up logging.
+//Initialize performs package-level setup. This must be called before calling any other package functionality, as it sets up global configuration.
 func Initialize(configPath string) (err error) {
 	initSCAMPLogger()
 	err = initConfig(configPath)

--- a/scamp/service.go
+++ b/scamp/service.go
@@ -71,8 +71,8 @@ func NewService(sector string, serviceSpec string, humanName string) (serv *Serv
 
 	serv.actions = make(map[string]*ServiceAction)
 
-	crtPath := defaultConfig.ServiceCertPath(serv.humanName)
-	keyPath := defaultConfig.ServiceKeyPath(serv.humanName)
+	crtPath := DefaultConfig().ServiceCertPath(serv.humanName)
+	keyPath := DefaultConfig().ServiceKeyPath(serv.humanName)
 
 	if crtPath == nil || keyPath == nil {
 		err = fmt.Errorf("could not find valid crt/key pair for service %s (`%s`,`%s`)", serv.humanName, crtPath, keyPath)


### PR DESCRIPTION
This PR adds some functionality for using the library without as much reliance on the file system.

-  `SetDefaultConfig()` sets the global `defaultConfig` to some arbitrary `Config` struct, which allows users to construct `Config`s without a config file
- `Config.Set()` allows the user to set `Config` k/v pairs at runtime
- `NewServiceExplicitCert` is exactly the same as `NewService` but allows the user to specify a `tls.Cert` and some `[]byte` for the in-memory PEM cert

It also fixes a bug where `DiscoveryMulticastIP` returned a nonsensical `IP` struct (direct cast from string). That function now uses `ParseIP`. 

A great deal of misleading (no longer accurate) documentation was removed, and new function-level documentation was added, along with more consistent error messages.

