### PR TITLE
reverting deadlock fix

### DIFF
--- a/scamp/client.go
+++ b/scamp/client.go
@@ -137,7 +137,6 @@ forLoop:
 				client.openRepliesLock.Unlock()
 
 				replyChan <- message
-				break forLoop
 			} else {
 				Trace.Printf("Could not handle msg, it's neither req or reply. Skipping.")
 				Error.Printf("Could not handle msg, it's neither req or reply. Skipping.")


### PR DESCRIPTION
Reverting the previous fix for deadlocks. The change was causing connections to close prematurely, resulting in scamp clients trying to use a closed connection for subsequent requests.