### PR TITLE
ROP-6958 kube liveness probe support

### DIFF
--- a/scamp/service.go
+++ b/scamp/service.go
@@ -277,11 +277,12 @@ func (serv *Service) RemoveClient(client *Client) (err error) {
 
 // Stop closes the service's net.Listener
 func (serv *Service) Stop() {
-	// Sometimes we Stop() before service after service has been init but before it is started
-	// The usual case is a bad config in another plugin
 	if serv.listener != nil {
 		serv.listener.Close()
 	}
+	fmt.Println("shutting down")
+	time.Sleep(time.Second * 10)
+	fmt.Println("shutdown done")
 }
 
 // MarshalText serializes a scamp service


### PR DESCRIPTION
## Description
Added writing and deleting of a file to "/backplane/running-services" for use by kubernetes to determine if a process in a container is still running.

## Jira Tickets
https://gudtech.atlassian.net/browse/ROP-6958

## Related Pull Requests
n/a

## Notes
