### PR TITLE
Local discovery multicast switch

### DIFF
--- a/scamp/config.go
+++ b/scamp/config.go
@@ -145,6 +145,11 @@ func (conf *Config) DiscoveryMulticastPort() (port int) {
 	return
 }
 
+func (conf *Config) LocalDiscoveryMulticast() bool {
+	_, ok := conf.values["discovery.local_multicast"]
+	return ok
+}
+
 // Get returns the value of a given config option as a string, or false if it is not set.
 func (conf *Config) Get(key string) (value string, ok bool) {
 	valueBytes, ok := conf.values[key]

--- a/scamp/discoveryannounce.go
+++ b/scamp/discoveryannounce.go
@@ -22,7 +22,7 @@ func NewDiscoveryAnnouncer() (announcer *DiscoveryAnnouncer, err error) {
 	config := DefaultConfig()
 	announcer.multicastDest = &net.UDPAddr{IP: config.DiscoveryMulticastIP(), Port: config.DiscoveryMulticastPort()}
 	// announcer.multicastDest = &net.UDPAddr{IP: 127.0.0.1, Port: config.DiscoveryMulticastPort()}
-	announcer.multicastConn, err = localMulticastPacketConn()
+	announcer.multicastConn, err = localMulticastPacketConn(config)
 	if err != nil {
 		return
 	}

--- a/scamp/multicast.go
+++ b/scamp/multicast.go
@@ -18,13 +18,18 @@ func loopbackInterface() (lo *net.Interface, err error) {
 	return
 }
 
-func localMulticastPacketConn() (conn *ipv4.PacketConn, err error) {
+func localMulticastPacketConn(config *Config) (conn *ipv4.PacketConn, err error) {
 	// TODO fundamentally change how multicast is sent. I can't get the API to work
 	// without creating a listener socket first but I shouldn't need it.
 	// Had issues with running multiple services (heka and sdk_service) so I'm
 	// going to the let the OS pick the port. `127.0.0.1:5556` used to work! -XRL
 	localMulticastSpec := "127.0.0.1:"
-	// Trace.Printf("announce binding to port: `%s`", localMulticastSpec)
+
+	if config.LocalDiscoveryMulticast() {
+		addr := config.DiscoveryMulticastIP()
+		port := config.DiscoveryMulticastPort()
+		localMulticastSpec = fmt.Sprintf("%s:%d", addr, port)
+	}
 
 	udpConn, err := net.ListenPacket("udp", localMulticastSpec)
 	if err != nil {


### PR DESCRIPTION
## Description
Allows for a switch in soa.conf for Docker for Mac

Adding a `discovery.local_multicast = 1` to the config will make scamp use the multicast ip/port for discovery announcements rather than `127.0.01:`

## Jira Tickets

## Related Pull Requests

## Notes
