### PR TITLE
[ROP-7028] Graceful shutdown

### DIFF
--- a/scamp/authorizedservices_test.go
+++ b/scamp/authorizedservices_test.go
@@ -5,7 +5,7 @@ import "bytes"
 import "bufio"
 
 func TestAuthorizedServiceSpec(t *testing.T) {
-	Initialize("/etc/SCAMP/soa.conf")
+	Initialize("./../fixtures/sample_soa.conf")
 	cache := NewAuthorizedServicesCache()
 
 	reader := bytes.NewReader(testAuthorizedServices)

--- a/scamp/client.go
+++ b/scamp/client.go
@@ -94,9 +94,11 @@ func (client *Client) Send(msg *Message) (responseChan chan *Message, err error)
 
 // Close unlocks a client mutex and closes the connection
 func (client *Client) Close() {
-	client.CloseTimeout(30 * time.Second)
+	client.CloseTimeout(time.Second * time.Duration(defaultCloseTimeout))
 }
 
+// CloseTimeout takes defaultCloseTimeout which defaults to 30 seconds but can be
+// set via the "timeout" flag
 func (client *Client) CloseTimeout(timeoutPeriod time.Duration) {
 	if len(client.spIdent) > 0 {
 		sp := DefaultCache.Retrieve(client.spIdent)

--- a/scamp/client.go
+++ b/scamp/client.go
@@ -94,6 +94,10 @@ func (client *Client) Send(msg *Message) (responseChan chan *Message, err error)
 
 // Close unlocks a client mutex and closes the connection
 func (client *Client) Close() {
+	client.CloseTimeout(30 * time.Second)
+}
+
+func (client *Client) CloseTimeout(timeoutPeriod time.Duration) {
 	if len(client.spIdent) > 0 {
 		sp := DefaultCache.Retrieve(client.spIdent)
 		if sp != nil {
@@ -110,7 +114,6 @@ func (client *Client) Close() {
 		return
 	}
 
-	timeoutPeriod := 30 * time.Second
 	after := time.After(timeoutPeriod)
 
 ClientClose:

--- a/scamp/discoveryannounce.go
+++ b/scamp/discoveryannounce.go
@@ -2,6 +2,9 @@ package scamp
 
 import (
 	"net"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"golang.org/x/net/ipv4"
@@ -13,6 +16,7 @@ type DiscoveryAnnouncer struct {
 	multicastConn *ipv4.PacketConn
 	multicastDest *net.UDPAddr
 	stopSig       (chan bool)
+	termSig       (chan os.Signal)
 }
 
 // NewDiscoveryAnnouncer creates a DiscoveryAnnouncer
@@ -20,6 +24,8 @@ func NewDiscoveryAnnouncer() (announcer *DiscoveryAnnouncer, err error) {
 	announcer = new(DiscoveryAnnouncer)
 	announcer.services = make([]*Service, 0, 0)
 	announcer.stopSig = make(chan bool)
+	announcer.termSig = make(chan os.Signal, 1)
+	signal.Notify(announcer.termSig, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 
 	config := DefaultConfig()
 	announcer.multicastDest = &net.UDPAddr{IP: config.DiscoveryMulticastIP(), Port: config.DiscoveryMulticastPort()}
@@ -54,6 +60,9 @@ func (announcer *DiscoveryAnnouncer) AnnounceLoop() {
 	for {
 		select {
 		case <-announcer.stopSig:
+			return
+		case <-announcer.termSig:
+			Info.Printf("caught sig term, stopping announce loop")
 			return
 		default:
 			announcer.doAnnounce()

--- a/scamp/discoveryannounce.go
+++ b/scamp/discoveryannounce.go
@@ -40,7 +40,10 @@ func NewDiscoveryAnnouncer() (announcer *DiscoveryAnnouncer, err error) {
 
 // Stop notifies stopSig channel to stop announcer
 func (announcer *DiscoveryAnnouncer) Stop() {
-	announcer.stopSig <- true
+	select {
+	case announcer.stopSig <- true:
+	default:
+	}
 }
 
 // Track indicates that announcer should track and announce service
@@ -59,6 +62,7 @@ func (announcer *DiscoveryAnnouncer) AnnounceLoop() {
 		case <-announcer.stopSig:
 			return
 		case <-announcer.termSig:
+			Info.Printf("caught sig term, stopping announce loop")
 			return
 		default:
 			announcer.doAnnounce()

--- a/scamp/discoveryannounce_test.go
+++ b/scamp/discoveryannounce_test.go
@@ -1,0 +1,19 @@
+package scamp
+
+import "testing"
+
+func TestTrack(t *testing.T) {
+	Initialize("./../fixtures/sample_soa.conf")
+
+	serv := &Service{}
+	a, err := NewDiscoveryAnnouncer()
+	if err != nil {
+		t.Fatalf("could not create announcer: %s", err)
+	}
+
+	a.Track(serv)
+
+	if len(a.services) != 1 {
+		t.Fatalf("expected 1 service in s.services, found %v", len(a.services))
+	}
+}

--- a/scamp/packet_test.go
+++ b/scamp/packet_test.go
@@ -89,7 +89,7 @@ func TestFailGarbage(t *testing.T) {
 }
 
 func TestFailHeaderParams(t *testing.T) {
-	Initialize("/etc/SCAMP/soa.conf")
+	Initialize("./../fixtures/sample_soa.conf")
 	byteReader := bufio.NewReader(bytes.NewReader([]byte("HEADER 1\r\n{\"action\":\"foo\",\"version\":1,\"envelope\":\"json\"}END\r\n")))
 	byteRdrWrtr := bufio.NewReadWriter(byteReader, nil)
 

--- a/scamp/scamp.go
+++ b/scamp/scamp.go
@@ -16,7 +16,7 @@ import (
 	"strconv"
 )
 
-var defaultCloseTimeout = 30
+var defaultCloseTimeout int64 = 30
 
 func main() {
 	var keyPath string
@@ -53,7 +53,7 @@ func main() {
 		if err != nil {
 			fmt.Printf("Could not parse closeTimout flag, using defaultTimeout (30 seconds)")
 		} else {
-			defaultCloseTimeout = seconds
+			defaultCloseTimeout = int64(seconds)
 		}
 	}
 }

--- a/scamp/scamp.go
+++ b/scamp/scamp.go
@@ -13,13 +13,17 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"strconv"
 )
+
+var defaultCloseTimeout = 30
 
 func main() {
 	var keyPath string
 	var certPath string
 	var fingerprintPath string
 	var announcePath string
+	var closeTimout string
 
 	gtConfigPathPtr := flag.String("config", "/backplane/discovery/discovery", "path to the discovery file")
 
@@ -27,6 +31,7 @@ func main() {
 	flag.StringVar(&certPath, "certpath", "", "path to cert used for signing")
 	flag.StringVar(&keyPath, "keypath", "", "path to service private key")
 	flag.StringVar(&fingerprintPath, "fingerprintpath", "", "path to cert to fingerprint")
+	flag.StringVar(&closeTimout, "timeout", "", "amount of time (in seconds) to wait before shutting down. Default is 30s")
 	flag.Parse()
 
 	Initialize(*gtConfigPathPtr)
@@ -43,6 +48,14 @@ func main() {
 		doCertFingerprint(fingerprintPath)
 	}
 
+	if len(closeTimout) != 0 {
+		seconds, err := strconv.Atoi(closeTimout)
+		if err != nil {
+			fmt.Printf("Could not parse closeTimout flag, using defaultTimeout (30 seconds)")
+		} else {
+			defaultCloseTimeout = seconds
+		}
+	}
 }
 
 func doFakeDiscoveryCache(keyPath, certPath, announcePath string) {

--- a/scamp/service.go
+++ b/scamp/service.go
@@ -276,6 +276,25 @@ func (serv *Service) RemoveClient(client *Client) (err error) {
 
 // Stop closes the service's net.Listener
 func (serv *Service) Stop() {
+	after := time.After(30 * time.Second)
+
+ServiceWait:
+	for {
+		select {
+		case <-after:
+			break ServiceWait
+		default:
+		}
+
+		serv.clientsM.Lock()
+		clientsLength := len(serv.clients)
+		serv.clientsM.Unlock()
+
+		if clientsLength == 0 {
+			break
+		}
+	}
+
 	if serv.listener != nil {
 		serv.listener.Close()
 	}

--- a/scamp/service.go
+++ b/scamp/service.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+
 	// "encoding/json"
 	"bytes"
 	"fmt"
@@ -278,9 +279,11 @@ func (serv *Service) RemoveClient(client *Client) (err error) {
 
 // Stop closes the service's net.Listener
 func (serv *Service) Stop() {
-	serv.StopTimeout(30 * time.Second)
+	serv.StopTimeout(time.Second * time.Duration(defaultCloseTimeout))
 }
 
+// StopTimeout takes defaultCloseTimeout which defaults to 30 seconds but can be
+// set via the "timeout" flag
 func (serv *Service) StopTimeout(timeoutPeriod time.Duration) {
 	after := time.After(timeoutPeriod)
 	ticker := time.NewTicker(1 * time.Second)

--- a/scamp/service.go
+++ b/scamp/service.go
@@ -278,7 +278,10 @@ func (serv *Service) RemoveClient(client *Client) (err error) {
 
 // Stop closes the service's net.Listener
 func (serv *Service) Stop() {
-	timeoutPeriod := 30 * time.Second
+	serv.StopTimeout(30 * time.Second)
+}
+
+func (serv *Service) StopTimeout(timeoutPeriod time.Duration) {
 	after := time.After(timeoutPeriod)
 	ticker := time.NewTicker(1 * time.Second)
 

--- a/scamp/servicecache.go
+++ b/scamp/servicecache.go
@@ -117,6 +117,9 @@ func (cache *ServiceCache) Retrieve(ident string) (instance *serviceProxy) {
 }
 
 func (cache *ServiceCache) SearchByAction(sector, action string, version int, envelope string) (instances []*serviceProxy, err error) {
+	cache.cacheM.Lock()
+	defer cache.cacheM.Unlock()
+
 	mungedName := fmt.Sprintf("%s:%s~%d#%s", sector, action, version, envelope)
 	instances = cache.actionIndex[mungedName]
 	if len(instances) == 0 {


### PR DESCRIPTION
## Description
Waits for the service to handle all incoming requests and after all incoming requests are finished, calling serviceCache.Stop() waits for outgoing requests to finish before shutting down.

Also fixes a small issue in serviceCache where SearchByAction did not lock the index mutex which made concurrent map accesses possible.

## Jira Tickets
https://gudtech.atlassian.net/browse/ROP-7028

## Related Pull Requests

## Notes
