### PR TITLE
Add mockedScampRequester

### DIFF
--- a/scamp/mocked.go
+++ b/scamp/mocked.go
@@ -1,0 +1,67 @@
+package scamp
+
+import (
+	"context"
+	"fmt"
+)
+
+// Extremely simple mock for ScampRequester
+// mockRequests are maps with keys as paths (aka 'actions') and values as json strings
+type mockedScampRequester struct {
+	mockRequests map[string]string
+	mockErrors   []error
+}
+
+func NewMockedScampRequester(mocks map[string]string) *mockedScampRequester {
+	return &mockedScampRequester{
+		mockRequests: mocks,
+	}
+}
+
+func (r *mockedScampRequester) getMockedResponse(action string) (*Message, error) {
+	response, ok := r.mockRequests[action]
+
+	if !ok || (response == "") {
+		return nil, fmt.Errorf("No response was found for action: %s", action)
+	}
+
+	respMessage := NewResponseMessage()
+	respMessage.SetAction(action)
+	respMessage.Write([]byte(response))
+
+	return respMessage, nil
+}
+
+func (r *mockedScampRequester) MockErrors() []error {
+	return r.mockErrors
+}
+
+func (r *mockedScampRequester) addError(err error) {
+	r.mockErrors = append(r.mockErrors, err)
+}
+
+// MakeJSONRequest - required to satisfy the ScampRequester interface definition
+func (r *mockedScampRequester) MakeJSONRequest(ctx context.Context, mssg *Message, _ int, _ bool) (*Message, error) {
+
+	response, err := r.getMockedResponse(mssg.Action)
+
+	if err != nil {
+		err = fmt.Errorf("Error getting mocked response: %s", err)
+		r.addError(err)
+		return nil, err
+	}
+
+	return response, nil
+}
+
+// MakeChannelJSONRequest - required to satisfy the ScampRequester interface definition
+func (r *mockedScampRequester) MakeChannelJSONRequest(
+	c context.Context,
+	m *Message,
+	t int,
+	al bool,
+	ch chan *Message,
+	er chan error,
+) {
+	panic("MakeChannelJSONRequest NOT YET SUPPORTED")
+}

--- a/scamp/mocked_test.go
+++ b/scamp/mocked_test.go
@@ -1,0 +1,35 @@
+package scamp
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMockedScampRequester(t *testing.T) {
+
+	mocks := map[string]string{
+		"kids.tv.remote.fetch": `{"channel_id":123}`,
+		"godfriend.favors.ask": `{"items":[4,5,6]}`,
+		"bank.funds.withdraw":  "",
+	}
+
+	r := NewMockedScampRequester(mocks)
+
+	for act, res := range mocks {
+		mssg := NewMessage()
+		mssg.SetAction(act)
+		recv, _ := r.MakeJSONRequest(context.Background(), mssg, 10, false)
+
+		if res == "" {
+			if len(r.MockErrors()) == 0 {
+				t.Errorf("expected errors for empty response")
+			}
+			continue
+		}
+
+		if string(recv.Bytes()) != res {
+			t.Errorf("wrong response for action %s", act)
+		}
+	}
+
+}


### PR DESCRIPTION
## Description

A very simple mocked ScampRequester. To be implemented as:
```
func NewRequestWithMocks(mocks map[string]string) *http.Request {

	requester := scamp.NewMockedScampRequester(mocks) <<<<----

	plugins := Plugins{
		ScampRequester: requester,
	}

	request := httptest.NewRequest(http.MethodPost, "nowhere", nil)
	requestctx.WithPlugins(request, &plugins)
	return request
}
```
... where `mocks` is a map with keys as paths (actions) and values as json strings to return.
