### PR TITLE
Explicitly include RSA key exchange AES cipher suites in TLS client config

### DIFF
--- a/scamp/connection.go
+++ b/scamp/connection.go
@@ -56,6 +56,7 @@ func DialConnection(connspec string) (conn *Connection, err error) {
 		InsecureSkipVerify: true,
 		CipherSuites:       cipherSuites,
 	}
+	config.BuildNameToCertificate() //nolint:staticcheck // deprecated no-op, preserved to minimise diff
 
 	tlsConn, err := tls.Dial("tcp", connspec, config)
 	if err != nil {

--- a/scamp/connection.go
+++ b/scamp/connection.go
@@ -36,10 +36,26 @@ type Connection struct {
 // remote host
 func DialConnection(connspec string) (conn *Connection, err error) {
 	// Trace.Printf("Dialing connection to `%s`", connspec)
+
+	// Build cipher suite list from the current defaults plus RSA key exchange AES suites.
+	// Go 1.22+ removed RSA key exchange from the default list (GODEBUG tlsrsakey=0), but
+	// some internal Go services built with older toolchains (e.g. gt-auth-service) still
+	// require them. We add only the AES variants — RC4 and 3DES are intentionally excluded.
+	var cipherSuites []uint16
+	for _, cs := range tls.CipherSuites() {
+		cipherSuites = append(cipherSuites, cs.ID)
+	}
+	cipherSuites = append(cipherSuites,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+	)
+
 	config := &tls.Config{
 		InsecureSkipVerify: true,
+		CipherSuites:       cipherSuites,
 	}
-	config.BuildNameToCertificate()
 
 	tlsConn, err := tls.Dial("tcp", connspec, config)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Go 1.22+ removed RSA key exchange cipher suites from the default TLS client cipher suite list (`GODEBUG tlsrsakey=0`)
- Internal Go services built with older toolchains (e.g. `gt-auth-service`) only offer RSA key exchange suites, causing an immediate `EOF` when a Go 1.22+ client connects
- Fix: append the four RSA+AES suites to the modern defaults in `DialConnection`
- RC4 and 3DES are intentionally excluded to avoid introducing CVEs

**Cipher suites added:**
- `TLS_RSA_WITH_AES_128_GCM_SHA256`
- `TLS_RSA_WITH_AES_256_GCM_SHA384`
- `TLS_RSA_WITH_AES_128_CBC_SHA`
- `TLS_RSA_WITH_AES_256_CBC_SHA`

These lack forward secrecy but are not cryptographically broken. They are appropriate given `InsecureSkipVerify` is already set on these internal SCAMP connections.

**Long-term**: `gt-auth-service` should be upgraded to a modern Go version so it offers ECDHE cipher suites.

## Jira Tickets
https://gudtech.atlassian.net/browse/ROP-9188

🤖 Generated with [Claude Code](https://claude.ai/code)