### PR TITLE
Bump go directive to 1.26, x/net to v0.38.0, x/sys to v0.31.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,7 @@
 module github.com/gudtech/scamp-go
 
-go 1.17
+go 1.26
 
-require (
-	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d
-	golang.org/x/sys v0.0.0-20210423082822-04245dca01da // indirect
-)
+require golang.org/x/net v0.38.0
+
+require golang.org/x/sys v0.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,12 @@
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d h1:20cMwl2fHAzkJMEA+8J4JgqBQcQGzbisXo31MIeenXI=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da h1:b3NXsE2LusjYGGjL5bxEVZZORm/YEFFrWFjR8eFrw/c=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/scamp/packet.go
+++ b/scamp/packet.go
@@ -142,7 +142,7 @@ func (pkt *Packet) Write(writer io.Writer) (written int, err error) {
 	case ACK:
 		packetTypeBytes = ackBytes
 	default:
-		err = fmt.Errorf(fmt.Sprintf("unknown packetType `%d`", pkt.packetType))
+		err = fmt.Errorf("unknown packetType `%d`", pkt.packetType)
 		return
 	}
 

--- a/scamp/ticket_test.go
+++ b/scamp/ticket_test.go
@@ -22,7 +22,7 @@ func TestTicket(t *testing.T) {
 	t.Logf("pem path: %v", pemPath)
 	good, err := ioutil.ReadFile(dispatchPath)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatalf("%s", err.Error())
 	}
 
 	if good == nil {


### PR DESCRIPTION
## Summary
- Bumps `go` directive from `1.17` to `1.26`
- Bumps `golang.org/x/net` from `v0.0.0-20210805` to `v0.38.0`
- Bumps `golang.org/x/sys` from `v0.0.0-20210423` to `v0.31.0`

Fixes all 11 open Dependabot alerts (4 high, 7 medium).

## Jira Tickets
https://gudtech.atlassian.net/browse/ROP-9190

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)