### PR TITLE
Fix two latent scamp-go bugs: announce-parse panic + Send error swallow

### DIFF
--- a/scamp/connection.go
+++ b/scamp/connection.go
@@ -3,6 +3,7 @@ package scamp
 import (
 	"bufio"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -254,13 +255,17 @@ func (conn *Connection) routePacket(pkt *Packet) (err error) {
 
 const RetryLimit = 50
 
+// ErrConnectionClosed is returned by Send when a packet write fails because the
+// underlying connection is closed or broken; callers should reconnect/retry.
+var ErrConnectionClosed = errors.New("scamp: connection closed or broken during send")
+
 // Send sends a scamp message using the current *Connection
 func (conn *Connection) Send(msg *Message) (err error) {
 	if conn == nil {
 		return fmt.Errorf("cannot send on nil connection")
 	}
 	if conn.isClosed {
-		err = fmt.Errorf("connection already closed")
+		return fmt.Errorf("connection already closed")
 	}
 
 	conn.readWriterLock.Lock()
@@ -292,16 +297,12 @@ func (conn *Connection) Send(msg *Message) (err error) {
 				_, err := pkt.Write(conn.readWriter)
 				// TODO: should we actually blacklist this error?
 				if err != nil {
-					// temprarily
-					if strings.Contains(err.Error(), "use of closed connection") {
-						// NOTE: this error is intentionally swallowed (matches
-						// pre-existing behavior); the outer Send returns nil here.
-						break
-					}
-					// TODO: attempt to reconnect
-					if strings.Contains(err.Error(), "broken pipe") {
-						// NOTE: error intentionally swallowed (pre-existing behavior).
-						break
+					// A closed or broken connection won't recover by retrying;
+					// propagate so callers can detect it and reconnect/retry
+					// (previously these were swallowed and Send returned nil).
+					if strings.Contains(err.Error(), "use of closed connection") ||
+						strings.Contains(err.Error(), "broken pipe") {
+						return fmt.Errorf("%w: %v", ErrConnectionClosed, err)
 					}
 
 					if retries > RetryLimit {

--- a/scamp/serviceproxy.go
+++ b/scamp/serviceproxy.go
@@ -182,6 +182,9 @@ func newServiceProxy(classRecordsRaw []byte, certRaw []byte, sigRaw []byte) (sp 
 	if err != nil {
 		return
 	}
+	if len(classRecords) < 8 {
+		return nil, fmt.Errorf("malformed announce: expected at least 8 class records, got %d", len(classRecords))
+	}
 	// OMG, position-based, heterogenously typed values in an array suck to deal with.
 	err = json.Unmarshal(classRecords[0], &sp.version)
 	if err != nil {
@@ -268,6 +271,10 @@ func newServiceProxy(classRecordsRaw []byte, certRaw []byte, sigRaw []byte) (sp 
 			if err != nil {
 				Error.Printf("could not parse rawActionSpec: %s", rawActionSpec)
 				return nil, err
+			}
+
+			if len(actionsRawMessages) < 2 {
+				return nil, fmt.Errorf("malformed announce: action spec needs at least 2 entries, got %d", len(actionsRawMessages))
 			}
 
 			err = json.Unmarshal(actionsRawMessages[0], &classes[i].actions[j].actionName)


### PR DESCRIPTION
Both bugs were uncovered during the golangci-lint rollout (dead-assignment lint hits that were masking pre-existing bugs). Filed as ROP-9250.

## Bug 1 — `newServiceProxy` panics on malformed announce data
`serviceproxy.go`: after unmarshaling the announce, `classRecords[0..7]` and (per action) `actionsRawMessages[0..1]` were indexed with **no length check** — short/malformed discovery data → index-out-of-range **panic**. Added two length guards (`classRecords < 8`, `actionsRawMessages < 2`) that return a clean error instead. No behavior change for valid announces.

## Bug 2 — `Connection.Send` silently swallows write errors on a dead conn
`connection.go`: on `"use of closed connection"` / `"broken pipe"` write errors, the loop `break`ed and `Send` returned `nil` → **silent message loss**. Now returns a new `ErrConnectionClosed` sentinel (wrapping the underlying error) so callers can detect it and reconnect/retry. Also early-returns on a known-closed connection instead of writing anyway.

### ⚠️ Behavior change — `Send` now returns an error on dead-conn writes
Previously `Send` returned `nil` in these cases. All four in-repo callers already check the error and handle it well, so this is strictly an improvement:
- `requester.go` — retries (was: thought it sent, then hung until response-timeout) ✅
- `service.go` — closes the dead client ✅
- `client.go` / `action_options.go` — propagate / log ✅

Callers wanting to special-case it can use `errors.Is(err, scamp.ErrConnectionClosed)`.

## Verification
`go build` / `go vet` / `go test` all pass; golangci-lint (v2.12.2/go1.26) **0 issues**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)